### PR TITLE
Client: L3 and R3 are assigned to the front sensor

### DIFF
--- a/client/packages/vita_virtual_device/src/windows.rs
+++ b/client/packages/vita_virtual_device/src/windows.rs
@@ -101,7 +101,22 @@ impl Config {
                     button: DS4Buttons::TRIGGER_RIGHT,
                 },
             ]))),
-            front_touch_config: Some(TouchConfig::Touchpad),
+            front_touch_config: Some(TouchConfig::Zones(RTree::bulk_load(vec![
+                TouchZone {
+                    rect: Rectangle::from_corners(
+                        FRONT_TOUCHPAD_RECT.0,
+                        ((FRONT_TOUCHPAD_RECT.1).0 / 2, (FRONT_TOUCHPAD_RECT.1).1),
+                    ),
+                    button: DS4Buttons::THUMB_LEFT,
+                },
+                TouchZone {
+                    rect: Rectangle::from_corners(
+                        ((FRONT_TOUCHPAD_RECT.1).0 / 2, (FRONT_TOUCHPAD_RECT.0).0),
+                        FRONT_TOUCHPAD_RECT.1,
+                    ),
+                    button: DS4Buttons::THUMB_RIGHT,
+                },
+            ]))),
             trigger_config: TriggerConfig::Shoulder,
         }
     }


### PR DESCRIPTION
I added binding of L3 and R3 to the front touch sensor, similar to how it is done for R2 and L2 with the rear sensor. You have implemented this in your API but, for some reason, are not using it in any way. You might have your own reasons or plans though.

This seems to be what most people looking for gamepad emulation want. I'm not an expert in Rust, and may have left something out.

Thanks for your contribution to this repository. Your implementation through Rust is truly impressive.