### PR TITLE
Added gyroscope and accelerometer support (Windows)

### DIFF
--- a/client/packages/vita_virtual_device/src/lib.rs
+++ b/client/packages/vita_virtual_device/src/lib.rs
@@ -19,6 +19,7 @@ pub trait VitaVirtualDevice<ConfigSetter: ?Sized>: Sized {
     fn identifiers(&self) -> Option<&[OsString]>;
     fn set_config(&mut self, config: ConfigSetter) -> Result<()>;
     fn send_report(&mut self, report: vita_reports::MainReport) -> Result<()>;
+    fn f32_to_i16(value: f32, min_value: f32, max_value: f32) -> i16;
 }
 
 cfg_if::cfg_if! {

--- a/server/src/ctrl.cpp
+++ b/server/src/ctrl.cpp
@@ -35,8 +35,11 @@ convert_touch_data(flatbuffers::FlatBufferBuilder &builder,
 
 flatbuffers::FlatBufferBuilder get_ctrl_as_netprotocol() {
   SceCtrlData pad;
-  SceMotionSensorState motion_data; // TODO: Needs calibration
+  SceMotionState motion_data; // TODO: Needs calibration
   SceTouchData touch_data_front, touch_data_back;
+
+  sceMotionSetGyroBiasCorrection(1);
+  sceMotionSetTiltCorrection(1);
 
   flatbuffers::FlatBufferBuilder builder(512);
 
@@ -49,12 +52,12 @@ flatbuffers::FlatBufferBuilder get_ctrl_as_netprotocol() {
   sceTouchPeek(SCE_TOUCH_PORT_BACK, &touch_data_back, 1);
   auto data_back = convert_touch_data(builder, touch_data_back);
 
-  sceMotionGetSensorState(&motion_data, 1);
-  NetProtocol::Vector3 accel(motion_data.accelerometer.x,
-                             motion_data.accelerometer.y,
-                             motion_data.accelerometer.z);
-  NetProtocol::Vector3 gyro(motion_data.gyro.x, motion_data.gyro.y,
-                            motion_data.gyro.z);
+  sceMotionGetState(&motion_data);
+  NetProtocol::Vector3 accel(motion_data.acceleration.x,
+                             motion_data.acceleration.y,
+                             motion_data.acceleration.z);
+  NetProtocol::Vector3 gyro(motion_data.angularVelocity.x, motion_data.angularVelocity.y,
+                            motion_data.angularVelocity.z);
   NetProtocol::MotionData motion(gyro, accel);
 
   auto content =

--- a/server/src/ctrl.cpp
+++ b/server/src/ctrl.cpp
@@ -55,7 +55,7 @@ flatbuffers::FlatBufferBuilder get_ctrl_as_netprotocol() {
                              motion_data.accelerometer.z);
   NetProtocol::Vector3 gyro(motion_data.gyro.x, motion_data.gyro.y,
                             motion_data.gyro.z);
-  NetProtocol::MotionData motion(accel, gyro);
+  NetProtocol::MotionData motion(gyro, accel);
 
   auto content =
       NetProtocol::CreatePad(builder, &buttons, pad.lx, pad.ly, pad.rx, pad.ry,


### PR DESCRIPTION
The basic strapping has already been created by you, there were just some corrections and logical additions.

- It seems that the gyroscope and accelerometer data being sent from the server side were mixed up with each other (https://github.com/musikid/VitaPad/commit/40742cabcd0119dfa9f109347177f24b4ff8d7ae);
- The main issue is that the DS4 emulation waits for a vector in `i16`, while the PS Vita sends `f32`. I decided to normalize the data from one format to the other (https://github.com/musikid/VitaPad/commit/f4f2072b558c08fe9be1aaadf72834f0df96aa4a).
  - No problem with the accelerometer, as the data coming from the PS Vita ranges from _-1.0_ to _1.0_.
  - The main problem was with the gyroscope data, as I couldn't find accurate data on the possible maximum and minimum values that the PS Vita can give. Empirically I was able to get values above 10. I chose _-35.0_ to _35.0_ as a working option, which is correctly displayed in the [Yuzu](https://yuzu-emu.org/) controller [settings](https://yuzu-emu.org/wiki/faq/#how-do-i-set-up-my-controls) (rotating square). Yuzu correctly displayed all the rotations, repeating exactly what I am doing.
- I replaced [`SceMotionSensorState`](https://docs.vitasdk.org/group__SceMotionUser.html#structSceMotionSensorState) with [`SceMotionState`](https://docs.vitasdk.org/group__SceMotionUser.html#structSceMotionState) as I favored the algorithms to calibrate and calculate the values of the PS Vita itself, while adding the [`sceMotionSetGyroBiasCorrection`](https://docs.vitasdk.org/group__SceMotionUser.html#ga1c93f4044ba6e72c531ffef885f1e099) and [`sceMotionSetTiltCorrection`](https://docs.vitasdk.org/group__SceMotionUser.html#gadea31e55ccfc5cf7231631cf45db7d3a) instructions (https://github.com/musikid/VitaPad/commit/c0647fa8d588d433aeb3c691874e3d6636bbdbb9).

At this point, the gyroscope works fine in Yuzu and is well defined in Steam. Accelerometer I can check only in numbers, I haven't found a game where it would be used.